### PR TITLE
fix issue #1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,5 +28,5 @@ jobs:
       - name: Upload result
         uses: actions/upload-artifact@v4
         with:
-          name: go60.uf2
+          name: go60.uf2.zip
           path: go60.uf2


### PR DESCRIPTION
Fixing issue #1 build result is a .zip but download shows .uf2. To flash, a rename and unzip is required on moergo go60.
This changes the resulting name to show the .zip properly. 

