### PR TITLE
ci: bump github actions and cachix ecosystem versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,18 +6,18 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: moergo-sc/zmk
           ref: main
           path: src
-      - uses: cachix/install-nix-action@v25
+      - uses: cachix/install-nix-action@v31
         with:
           nix_path: nixpkgs=channel:nixos-22.05
-      - uses: cachix/cachix-action@v14
+      - uses: cachix/cachix-action@v17
         with:
           name: moergo-glove80-zmk-dev
           skipPush: true


### PR DESCRIPTION
Bump the following GitHub Actions and dependencies to modern, maintained versions. This eliminates the Node.js runtime deprecation warnings:

* `actions/checkout` bumped to `v6`
* `cachix/install-nix-action` bumped from `v25` to `v31`
* `cachix/cachix-action` bumped from `v14` to `v17`
* `actions/upload-artifact` bumped from `v4` to `v7`